### PR TITLE
fix screenshot link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ What does this mean?
 
 [Reverse Polish Notation]: https://en.wikipedia.org/wiki/Reverse_Polish_notation
 
-![A screenshot of esc in use, taken from the esc documentation.](https://esc-calc.readthedocs.io/en/oneoh/_images/register-use.png)
+![A screenshot of esc in use, taken from the esc documentation.](https://esc-calc.readthedocs.io/en/latest/_images/register-use.png)
 
 Installation
 ============


### PR DESCRIPTION
This accidentally pointed to my 1.0 release branch, so when I cleaned up the alternate branches on Read The Docs, it stopped working.